### PR TITLE
Make fg fail color configurable for command

### DIFF
--- a/segments/command.bash
+++ b/segments/command.bash
@@ -1,5 +1,6 @@
 ### Defaults
 _sbp_command_color_fg=${_sbp_command_color_fg:-$_sbp_color_dgrey}
+_sbp_command_color_fg_fail=${_sbp_command_color_fg_fail:-$_sbp_color_lgrey}
 _sbp_command_color_bg_fail=${_sbp_command_color_fail:-$_sbp_color_red}
 _sbp_command_color_bg_success=${_sbp_command_color_bg_success:-$_sbp_color_lgrey}
 
@@ -9,6 +10,7 @@ function _sbp_generate_command_segment {
     _sbp_command_color_bg="$_sbp_command_color_bg_success"
   else
     _sbp_command_color_bg="$_sbp_command_color_bg_fail"
+    _sbp_command_color_fg="$_sbp_command_color_fg_fail"
   fi
 
   command_value="last: ${_sbp_timer_m}m ${_sbp_timer_s}s"

--- a/segments/command.bash
+++ b/segments/command.bash
@@ -5,17 +5,18 @@ _sbp_command_color_bg_fail=${_sbp_command_color_fail:-$_sbp_color_red}
 _sbp_command_color_bg_success=${_sbp_command_color_bg_success:-$_sbp_color_lgrey}
 
 function _sbp_generate_command_segment {
-  local command_value
+  local command_value command_color_fg
   if [[ "$_sbp_current_exec_result" -eq 0 || "$_sbp_current_exec_result" -eq 130 ]]; then
     _sbp_command_color_bg="$_sbp_command_color_bg_success"
+    command_color_fg="$_sbp_command_color_fg"
   else
     _sbp_command_color_bg="$_sbp_command_color_bg_fail"
-    _sbp_command_color_fg="$_sbp_command_color_fg_fail"
+    command_color_fg="$_sbp_command_color_fg_fail"
   fi
 
   command_value="last: ${_sbp_timer_m}m ${_sbp_timer_s}s"
 
-  _sbp_segment_new_color_fg="$_sbp_command_color_fg"
+  _sbp_segment_new_color_fg="$command_color_fg"
   _sbp_segment_new_color_bg="$_sbp_command_color_bg"
   _sbp_segment_new_length="$(( ${#command_value} + 2 ))"
   _sbp_segment_new_value=" ${command_value} "

--- a/settings.default
+++ b/settings.default
@@ -13,6 +13,7 @@ _sbp_settings_segments_right=('command' 'timestamp')
 _sbp_settings_prompt_ready_color="$_sbp_color_dgrey"
 _sbp_command_color_bg="$_sbp_color_lgrey"
 _sbp_command_color_fg="$_sbp_color_dgrey"
+_sbp_command_color_fg_fail="$_sbp_color_lgrey"
 _sbp_filler_color_bg="$_sbp_color_empty"
 _sbp_filler_color_fg="$_sbp_color_empty"
 _sbp_git_color_bg="$_sbp_color_green"


### PR DESCRIPTION
- Make fg fail color configurable for command
- Default to lgrey. The dgrey is hard to read against the red, for me.

This is the before & after:

![screenshot - 16-03-14 - 05 36 07 pm](https://cloud.githubusercontent.com/assets/47756/13764354/ab35295a-ea0b-11e5-8236-2385e182dc8f.png)