### PR TITLE
New alert setting for icon in `notify-send` popup

### DIFF
--- a/hooks/alert.bash
+++ b/hooks/alert.bash
@@ -1,4 +1,5 @@
 _sbp_alert_threshold="${_sbp_trigger_alert_hook:-1}"
+_sbp_alert_icon="${_sbp_alert_icon:-bash}"
 
 function _sbp_alert_exec() { # User notification
   [[ -z "$2" ]] && echo "I need a title and a message" && return
@@ -11,7 +12,7 @@ function _sbp_alert_exec() { # User notification
   elif [[ "$(uname -s)" == "Darwin" ]]; then
     osascript -e "display notification \"$message\" with title \"$title\""
   elif type notify-send &> /dev/null; then
-    (notify-send "$title" "$message" &)
+    (notify-send --icon="$_sbp_alert_icon" "$title" "$message" &)
   fi
 }
 

--- a/settings.default
+++ b/settings.default
@@ -36,3 +36,5 @@ _sbp_timestamp_format=%H:%M:%S
 
 # Switches for enabling and disabling functionality.
 _sbp_path_disable_sep=0
+
+_sbp_alert_icon=bash


### PR DESCRIPTION
Didn't end up changing the title, just the icon:

- Add new setting to display icon in `notify-send` popup
- Add defaults to settings.default

If you don't set the icon, it currently default to the `bash` icon that your theme sets. If you set it to an empty string, then you won't get an icon - the old behaviour. 

Looks like this in use:

![image](https://cloud.githubusercontent.com/assets/47756/13963448/9f14c262-f022-11e5-95da-bcd4d34880fb.png)

