### PR TITLE
enable backgroud color settings of prompt ready

### DIFF
--- a/sbp.bash
+++ b/sbp.bash
@@ -53,7 +53,7 @@ function _sbp_set_prompt {
   if [[ "$_sbp_enabled" -eq 1 ]]; then
     _sbp_perform_trigger_hooks
     _sbp_generate_segments
-    PS1="\n${_sbp_prompt_left_value}${_sbp_prompt_right_value}${_sbp_color_reset}\n$(_sbp_color_print_escaped "${_sbp_settings_prompt_ready_color}") ${_sbp_char_ready} ${_sbp_color_reset}"
+    PS1="\n${_sbp_prompt_left_value}${_sbp_prompt_right_value}${_sbp_color_reset}\n$(_sbp_color_print_escaped "${_sbp_settings_prompt_ready_color}" "${_sbp_settings_prompt_ready_color_bg}")${_sbp_char_ready} ${_sbp_color_reset}"
   fi
 }
 

--- a/settings.default
+++ b/settings.default
@@ -11,6 +11,7 @@ _sbp_settings_segments_right=('command' 'timestamp')
 # Colors can be changed at will. Run 'sbp colors'
 # to list all available colors
 _sbp_settings_prompt_ready_color="$_sbp_color_dgrey"
+_sbp_settings_prompt_ready_color_bg="$_sbp_color_empty"
 _sbp_command_color_bg="$_sbp_color_lgrey"
 _sbp_command_color_fg="$_sbp_color_dgrey"
 _sbp_command_color_fg_fail="$_sbp_color_lgrey"


### PR DESCRIPTION
enable backgroud color settings of prompt ready, and remove the leading space of prompt ready char