### PR TITLE
Simplifying oscheck for DEBUG

### DIFF
--- a/sbp.bash
+++ b/sbp.bash
@@ -6,14 +6,10 @@ export sbp_path
 #shellcheck source=helpers/cli.bash
 source "${sbp_path}/helpers/cli.bash"
 
-if [[ "$OSTYPE" == "linux-gnu" ]]; then
-  date_cmd='date'
-elif [[ "$OSTYPE" == "darwin"* ]]; then
-  # Mac OSX
+if [[ "$OSTYPE" == "darwin"* ]]; then
   date_cmd='gdate'
 else
-  # Unknown.
-  date_cmd='gdate'
+  date_cmd='date'
 fi
 
 function _sbp_timer_start() {


### PR DESCRIPTION
This failed on my raspberry pie due to its ```OSTYPE``` being ```linux-gnueabihf```, and given that only OSX (afaik) ships with shitty core utils, I think this will suffice.  