### PR TITLE
Fix aliased rm

### DIFF
--- a/sbp.bash
+++ b/sbp.bash
@@ -10,9 +10,9 @@ source "${SBP_PATH}/src/interact.bash"
 source "${SBP_PATH}/src/debug.bash"
 
 if [[ -d "/run/user/${UID}" ]]; then
-  SBP_TMP=$(mktemp -d --tmpdir="/run/user/${UID}") && trap 'rm -rf "$SBP_TMP"' EXIT;
+  SBP_TMP=$(mktemp -d --tmpdir="/run/user/${UID}") && trap 'command rm -rf "$SBP_TMP"' EXIT;
 else
-  SBP_TMP=$(mktemp -d) && trap 'rm -rf "$SBP_TMP"' EXIT;
+  SBP_TMP=$(mktemp -d) && trap 'command rm -rf "$SBP_TMP"' EXIT;
 fi
 
 export SBP_TMP
@@ -27,7 +27,7 @@ _sbp_set_prompt() {
   if [[ -f "${SBP_TMP}/execution" ]]; then
     command_start=$(< "${SBP_TMP}/execution")
     command_duration=$(( current_time - command_start ))
-    rm "${SBP_TMP}/execution"
+    command rm "${SBP_TMP}/execution"
   else
     command_duration=0
     command_status=0

--- a/src/interact.bash
+++ b/src/interact.bash
@@ -76,7 +76,7 @@ _sbp_peekaboo() {
 
   if [[ -f "$feature_hook" || -f "$feature_segment" ]]; then
     if [[ -f "$peekaboo_file" ]]; then
-      rm "$peekaboo_file"
+      command rm "$peekaboo_file"
     else
       touch "$peekaboo_file"
     fi

--- a/src/segments/rescuetime.bash
+++ b/src/segments/rescuetime.bash
@@ -40,7 +40,7 @@ segments::rescuetime_refresh() {
 
   if [[ -z "$result" ]]; then
     # No data, so no logging of time today
-    rm -f "$SEGMENT_CACHE"
+    command rm -f "$SEGMENT_CACHE"
     return 0
   fi
 

--- a/test/hooks/hook_helper.bash
+++ b/test/hooks/hook_helper.bash
@@ -4,7 +4,7 @@ source "${SBP_PATH}/test/asserts.bash"
 export COMMAND_EXIT_CODE=0
 export COMMAND_DURATION=0
 HOOK_NAME="$(basename "$BATS_TEST_FILENAME" .bats)"
-TMP_DIR=$(mktemp -d) && trap 'rm -rf "$TMP_DIR"' EXIT;
+TMP_DIR=$(mktemp -d) && trap 'command rm -rf "$TMP_DIR"' EXIT;
 
 source_hook() {
   hook_source="${SBP_PATH}/src/hooks/${HOOK_NAME}.bash"

--- a/test/main.bats
+++ b/test/main.bats
@@ -3,7 +3,7 @@
 source "${SBP_PATH}/test/asserts.bash"
 
 SRC_NAME="$(basename "$BATS_TEST_FILENAME" .bats)"
-TMP_DIR=$(mktemp -d) && trap 'rm -rf "$TMP_DIR"' EXIT;
+TMP_DIR=$(mktemp -d) && trap 'command rm -rf "$TMP_DIR"' EXIT;
 
 setup() {
   export SBP_CONFIG="${TMP_DIR}/local_config"

--- a/test/segments/k8s.bats
+++ b/test/segments/k8s.bats
@@ -16,7 +16,7 @@ EOF
 }
 
 @test "test no config k8s segment" {
-  rm "$KUBE_CONFIG"
+  command rm "$KUBE_CONFIG"
   result="$(execute_segment)"
   assert_equal "$result" ''
 }

--- a/test/segments/rescuetime.bats
+++ b/test/segments/rescuetime.bats
@@ -31,7 +31,7 @@ EOF
 
 @test "test a refreshing the rescuetime segment" {
   SEGMENT_CACHE="${TMP_DIR}/rescuetime"
-  rm -rf "$SEGMENT_CACHE"
+  command rm -rf "$SEGMENT_CACHE"
   RESCUETIME_ENDPOINT="http://localhost:8080"
 
   execute_segment

--- a/test/segments/segment_helper.bash
+++ b/test/segments/segment_helper.bash
@@ -4,7 +4,7 @@ source "${SBP_PATH}/test/asserts.bash"
 export COMMAND_EXIT_CODE=0
 export COMMAND_DURATION=0
 SEGMENT_NAME="$(basename "$BATS_TEST_FILENAME" .bats)"
-TMP_DIR=$(mktemp -d) && trap 'rm -rf "$TMP_DIR"' EXIT;
+TMP_DIR=$(mktemp -d) && trap 'command rm -rf "$TMP_DIR"' EXIT;
 
 source_segment() {
   segment_source="${SBP_PATH}/src/segments/${SEGMENT_NAME}.bash"

--- a/test/segments/wttr.bats
+++ b/test/segments/wttr.bats
@@ -25,7 +25,7 @@ segments::wttr_fetch_changes() {
 
 @test "test refreshing the wttr segment" {
   SEGMENT_CACHE="${TMP_DIR}/wttr"
-  rm -rf "$SEGMENT_CACHE"
+  command rm -rf "$SEGMENT_CACHE"
   execute_segment
   [[ -f "$SEGMENT_CACHE" ]]
 

--- a/test/src_helper.bash
+++ b/test/src_helper.bash
@@ -3,7 +3,7 @@ source "${SBP_PATH}/src/debug.bash"
 source "${SBP_PATH}/test/asserts.bash"
 
 SRC_NAME="$(basename "$BATS_TEST_FILENAME" .bats)"
-TMP_DIR=$(mktemp -d) && trap 'rm -rf "$TMP_DIR"' EXIT;
+TMP_DIR=$(mktemp -d) && trap 'command rm -rf "$TMP_DIR"' EXIT;
 
 source_src() {
   src_source="${SBP_PATH}/src/${SRC_NAME}.bash"


### PR DESCRIPTION
Always run `rm` command ignoring aliases. When user has `rm` aliased to e.g. `gio trash` sbp displays error instead of deleting files.

This probably should be done to all external programs, or at least for those that are frequently aliased.