### PR TITLE
Fix COMMAND_DURATION read only

### DIFF
--- a/src/segments/command.bash
+++ b/src/segments/command.bash
@@ -5,7 +5,8 @@ segments::command() {
   local timer_s=0
 
   if [[ "$COMMAND_EXIT_CODE" -lt 0 || "$COMMAND_EXIT_CODE" -eq 130 ]]; then
-    COMMAND_DURATION=0
+    timer_m=0
+    timer_s=0
   fi
 
   if [[ "$COMMAND_DURATION" -gt 0 ]]; then


### PR DESCRIPTION
This fixes the following error
src/segments/command.bash: line 8: COMMAND_DURATION: readonly variable
that occurs when canceling an interactive password prompt while
connecting to an ssh server. This probably occurs at many other places,
too.