### PR TITLE
Fix wttr.in sometimes empty

### DIFF
--- a/src/segments/wttr.bash
+++ b/src/segments/wttr.bash
@@ -16,7 +16,7 @@ segments::wttr_refresh() {
   fi
 
   current_time=$(date +%s)
-  time_since_update=$(( current_time - last_update ))
+  time_since_update=$((current_time - last_update))
 
   if [[ $time_since_update -lt $refresh_rate ]]; then
     return 0
@@ -24,7 +24,6 @@ segments::wttr_refresh() {
 
   curl -H "Accept-Language: ${LANG%_*}" --compressed "wttr.in/${location}?format=${format}" | tr -d '\n' | tr ';' '\n' > "$SEGMENT_CACHE"
 }
-
 
 segments::wttr() {
   if [[ -f $SEGMENT_CACHE ]]; then

--- a/src/segments/wttr.bash
+++ b/src/segments/wttr.bash
@@ -5,11 +5,11 @@ format=${SETTINGS_WTTR_FORMAT:-'%p;%t;%w'}
 refresh_rate="${SEGMENTS_WTTR_REFRESH_RATE:-600}"
 
 segments::wttr_refresh() {
-  if [[ ! -f "$SEGMENT_CACHE" ]]; then
+  if [[ ! -f $SEGMENT_CACHE ]]; then
     debug::log "No cache folder"
   fi
 
-  if [[ -f "$SEGMENT_CACHE" ]]; then
+  if [[ -f $SEGMENT_CACHE ]]; then
     last_update=$(stat -f "%m" "$SEGMENT_CACHE")
   else
     last_update=0
@@ -18,7 +18,7 @@ segments::wttr_refresh() {
   current_time=$(date +%s)
   time_since_update=$(( current_time - last_update ))
 
-  if [[ "$time_since_update" -lt "$refresh_rate" ]]; then
+  if [[ $time_since_update -lt $refresh_rate ]]; then
     return 0
   fi
 
@@ -27,8 +27,8 @@ segments::wttr_refresh() {
 
 
 segments::wttr() {
-  if [[ -f "$SEGMENT_CACHE" ]]; then
-    mapfile -t result < "$SEGMENT_CACHE"
+  if [[ -f $SEGMENT_CACHE ]]; then
+    mapfile -t result <"$SEGMENT_CACHE"
     print_themed_segment 'normal' "${result[@]}"
   fi
   execute::execute_nohup_function segments::wttr_refresh

--- a/src/segments/wttr.bash
+++ b/src/segments/wttr.bash
@@ -22,7 +22,10 @@ segments::wttr_refresh() {
     return 0
   fi
 
-  curl -H "Accept-Language: ${LANG%_*}" --compressed "wttr.in/${location}?format=${format}" | tr -d '\n' | tr ';' '\n' > "$SEGMENT_CACHE"
+  weather_data="$(curl -H "Accept-Language: ${LANG%_*}" --compressed "wttr.in/${location}?format=${format}" | tr -d '\n' | tr ';' '\n')"
+  if [[ -n $weather_data ]]; then
+    echo "$weather_data" >"$SEGMENT_CACHE"
+  fi
 }
 
 segments::wttr() {


### PR DESCRIPTION
If you have no internet connection and the wttr.in segment gets refreshed
it will be an empty segment (only the arrow) until it gets refreshed again.

This checks if the response by wttr.in is empty and does not attempt
to write whitespace to the cache.