### PR TITLE
Fix `sbp list segments`, fix link to base16-builder

### DIFF
--- a/src/colors/README.md
+++ b/src/colors/README.md
@@ -14,4 +14,3 @@ file from your favorite color scheme. For instance like so:
 ```
 You can also set the colors to be `xresources` which will use whatever theme is
 set in your terminal/xresources config.
-

--- a/src/colors/template.ejs
+++ b/src/colors/template.ejs
@@ -1,4 +1,4 @@
-<%=/* this is for https://github.co/base16-builder/base16-builder  */%>
+<%=/* this is for https://github.com/base16-builder/base16-builder  */%>
 color00="<%- base["00"]["rgb"][0] %>;<%- base["00"]["rgb"][1] %>;<%- base["00"]["rgb"][2] %>"
 color01="<%- base["01"]["rgb"][0] %>;<%- base["01"]["rgb"][1] %>;<%- base["01"]["rgb"][2] %>"
 color02="<%- base["02"]["rgb"][0] %>;<%- base["02"]["rgb"][1] %>;<%- base["02"]["rgb"][2] %>"

--- a/src/interact_themed.bash
+++ b/src/interact_themed.bash
@@ -38,7 +38,7 @@ list_segments() {
     duration=$(debug::tick_timer 2>&1 | tr -d ':')
 
     echo "${segment_name}: ${status}" "$duration"
-  done | column -t -c " "
+  done | column -t
 }
 
 list_hooks() {


### PR DESCRIPTION
This fixes `sbp list segments`. `column -c` takes the output width not the a space. I am not sure what was intented here but the other column only has -t, too. So this should be fine. Also a quick link fix is included.