### PR TITLE
Fix wttr segment update

### DIFF
--- a/src/segments/wttr.bash
+++ b/src/segments/wttr.bash
@@ -16,7 +16,11 @@ segments::wttr_refresh() {
   fi
 
   if [[ -f $SEGMENT_CACHE ]]; then
-    last_update=$(stat -f "%m" "$SEGMENT_CACHE")
+    if [[ $OSTYPE =~ darwin || $(uname) == Darwin ]]; then
+      last_update=$(stat -f "%m" "$SEGMENT_CACHE")
+    else
+      last_update=$(stat -c "%Y" "$SEGMENT_CACHE")
+    fi
   else
     last_update=0
   fi


### PR DESCRIPTION
I just wondered why my bash prompt shows 15 degrees more than are really outside. Turns out this feature was bugged an never worked.

`stat -f "%m"` is invalid cause -f is mutually exclusive with any % letter combination.

-c "%y" return quote man page: "time of last data modification, seconds since Epoch"