### PR TITLE
Check Bash version in loading `sbp.bash`

### DIFF
--- a/sbp.bash
+++ b/sbp.bash
@@ -4,6 +4,21 @@
 #   Simple Bash Prompt (SBP)    #
 #################################
 
+# Check the Bash version.
+if [ ! -n "${BASH_VERSION-}" ]; then
+  printf 'sbp: This is not a Bash session. Bash 4.3 or higher is required by sbp.\n' >&2
+  return 1 2>/dev/null || exit 1
+elif [ ! -n "${BASH_VERSINFO-}" ] || ((BASH_VERSINFO[0] < 4 || BASH_VERSINFO[0] == 4 && BASH_VERSINFO[1] < 3)); then
+  printf 'sbp: This is Bash %s. Bash 4.3 or higher is required by sbp.\n' "$BASH_VERSION" >&2
+  return 1 2>/dev/null || exit 1
+fi
+
+# Do not set up prompts when it is not an interactive session.
+if [[ $- != *i* ]] && ! return 0 2>/dev/null; then
+  printf 'sbp: This is not an interactive session of Bash.\n' >&2
+  exit 1
+fi
+
 # shellcheck source=src/interact.bash
 source "${SBP_PATH}/src/interact.bash"
 # shellcheck source=src/debug.bash


### PR DESCRIPTION
`README.md` states that the minimal supported Bash version is 4.3, but it is not explicitly checked in the script currently. I would like to safely use Bash 4.3 features such as name references in upcoming PRs I'm planning to open. In this PR, the following conditions are checked at the beginning of `sbp.bash`:

- Whether it is executed in Bash,
- Whether it is executed in Bash-4.3+,
- Whether it is executed in an interactive session.

Implementation notes:

- There are shells that do not support the conditional command `[[ ... ]]`.
- Bash-1.* does not support the `BASH_VERSINFO` array.
- Bash-2.* does not support the conditional command `[[ ... ]]`.
- The builtin `return` fails with error messages when the file is directly executed as e.g. `bash sbp.bash`.
- There are systems that stop working when `bashrc` outputs something to `stderr`.