### PR TITLE
Use builtin `$EPOCHSECONDS` and `printf '%(FMT)T' -1` instead of the external command `date`

### DIFF
--- a/sbp.bash
+++ b/sbp.bash
@@ -19,11 +19,20 @@ export SBP_TMP
 export SBP_PATH
 export COLUMNS
 
+_sbp_get_current_time() {
+  if [[ ${EPOCHSECONDS-} ]]; then
+    printf -v "$1" %s "$EPOCHSECONDS"
+  else
+    printf -v "$1" '%(%s)T' -1
+  fi
+}
+export -f _sbp_get_current_time
+
 _sbp_set_prompt() {
   local command_status=$?
   local command_status current_time command_start command_duration
   [[ -n "$SBP_DEBUG" ]] && debug::start_timer
-  current_time=$(date +%s)
+  _sbp_get_current_time current_time
   if [[ -f "${SBP_TMP}/execution" ]]; then
     command_start=$(< "${SBP_TMP}/execution")
     command_duration=$(( current_time - command_start ))
@@ -46,7 +55,9 @@ _sbp_set_prompt() {
 }
 
 _sbp_pre_exec() {
-  date +%s > "${SBP_TMP}/execution"
+  local time
+  _sbp_get_current_time time
+  echo "$time" > "${SBP_TMP}/execution"
 }
 
 # shellcheck disable=SC2034

--- a/src/debug.bash
+++ b/src/debug.bash
@@ -2,7 +2,7 @@
 
 debug::log() {
   local timestamp file function
-  timestamp=$(date +'%y.%m.%d %H:%M:%S')
+  printf -v timestamp '%(%y.%m.%d %H:%M:%S)T' -1
   file="${BASH_SOURCE[1]##*/}"
   function="${FUNCNAME[1]}"
   >&2 printf '\n[%s] [%s - %s]: \e[31m%s\e[0m\n' "$timestamp" "$file" "$function" "${*}"
@@ -27,4 +27,3 @@ debug::tick_timer() {
   >&2 echo "${timer_spent}ms: $1"
   timer_start=$("$date_cmd" +'%s%3N')
 }
-

--- a/src/debug.bash
+++ b/src/debug.bash
@@ -8,22 +8,36 @@ debug::log() {
   >&2 printf '\n[%s] [%s - %s]: \e[31m%s\e[0m\n' "$timestamp" "$file" "$function" "${*}"
 }
 
-if [[ "$OSTYPE" == "darwin"* ]]; then
-  if type -P gdate &>/dev/null; then
-    date_cmd='gdate'
-  fi
+if [[ ${EPOCHREALTIME-} ]]; then
+  date_cmd=EPOCHREALTIME
 else
-  date_cmd='date'
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    if type -P gdate &>/dev/null; then
+      date_cmd='gdate'
+    fi
+  else
+    date_cmd='date'
+  fi
 fi
 
+debug::get_clock() {
+  if [[ $date_cmd == EPOCHREALTIME ]]; then
+    printf -v "$1" %s "${EPOCHREALTIME//[!0-9]}"
+    printf -v "$1" %s "${!1%???}" # strip 3 digits of microsec resolution
+  else
+    printf -v "$1" "$("$date_cmd" +'%s%3N')"
+  fi
+}
+
 debug::start_timer() {
-  timer_start=$("$date_cmd" +'%s%3N')
+  debug::get_clock timer_start
 }
 
 debug::tick_timer() {
   [[ -z "$date_cmd" ]] && return 0
-  timer_stop=$("$date_cmd" +'%s%3N')
+  local timer_stop timer_spent
+  debug::get_clock timer_stop
   timer_spent=$(( timer_stop - timer_start))
   >&2 echo "${timer_spent}ms: $1"
-  timer_start=$("$date_cmd" +'%s%3N')
+  debug::get_clock timer_start
 }

--- a/src/segments/rescuetime.bash
+++ b/src/segments/rescuetime.bash
@@ -24,7 +24,8 @@ segments::rescuetime_refresh() {
     last_update=0
   fi
 
-  current_time=$(date +%s)
+  local current_time
+  _sbp_get_current_time current_time
   time_since_update=$(( current_time - last_update ))
 
   if [[ "$time_since_update" -lt "$refresh_rate" ]]; then

--- a/src/segments/wttr.bash
+++ b/src/segments/wttr.bash
@@ -25,7 +25,8 @@ segments::wttr_refresh() {
     last_update=0
   fi
 
-  current_time=$(date +%s)
+  local current_time
+  _sbp_get_current_time current_time
   time_since_update=$((current_time - last_update))
 
   if [[ $time_since_update -lt $refresh_rate ]]; then


### PR DESCRIPTION
We can use these built-in features of Bash to reduce the spawn cost of the external command `date`.

- `$EPOCHSECONDS` and `$EPOCHREALTIME` are available in Bash 5.0+.
- `printf '%(FMT)T' -1` is available in Bash 4.2+.
- The decimal point of `$EPOCHREALTIME` depends on the locale.