### PR TITLE
Check deprecate configuration variables

### DIFF
--- a/sbp.bash
+++ b/sbp.bash
@@ -64,6 +64,7 @@ _sbp_set_prompt() {
   fi
   printf '\e]2;%s\007' "$title"
 
+  ((_sbp_set_prompt_count++))
   PS1=$(bash "${SBP_PATH}/src/main.bash" "$command_status" "$command_duration")
   [[ -n "$SBP_DEBUG" ]] && debug::tick_timer "Done"
 
@@ -77,5 +78,7 @@ _sbp_pre_exec() {
 
 # shellcheck disable=SC2034
 PS0="\$(_sbp_pre_exec)"
+
+export _sbp_set_prompt_count=0
 
 [[ "$PROMPT_COMMAND" =~ _sbp_set_prompt ]] || PROMPT_COMMAND="_sbp_set_prompt;$PROMPT_COMMAND"

--- a/src/configure.bash
+++ b/src/configure.bash
@@ -78,6 +78,148 @@ configure::set_layout() {
   fi
 }
 
+configure::deprecate::_is_warning_enabled() {
+  # shellcheck disable=SC2154 # _sbp_set_prompt_count is supposed to be
+  # exported by the parent shell.
+  ((_sbp_set_prompt_count <= 1))
+}
+
+configure::deprecate::_warn_proc() {
+  local old_config_name=$1 new_config_name=${2-} message=${3-}
+  local sgr0=$'\e[m' sgr_old=$'\e[1;31m' sgr_new=$'\e[1;34m'
+  if [[ ! $message && $new_config_name ]]; then
+    message="Please use '$sgr_new$new_config_name$sgr0'."
+  fi
+  printf '\e[35m%s\e[36m:\e[32m%s\e[36m:\e[m %s\n' "${BASH_SOURCE[1]}" "${BASH_LINENO[0]}" "'$sgr_old$old_config_name$sgr0' is deprecated.${message:+ $message}" >/dev/tty
+}
+
+configure::deprecate::_add_scalar() {
+  local old_config_name=$1 new_config_name=$2
+  local fallback_variable=${new_config_name:-_sbp_configure_deprecate__$old_config_name}
+  if configure::deprecate::_is_warning_enabled; then
+    # shellcheck disable=SC1087
+    declare -gn "$old_config_name=$fallback_variable[\$(configure::deprecate::_warn_proc '$old_config_name' '$new_config_name')]"
+  else
+    declare -gn "$old_config_name=$fallback_variable"
+  fi
+  _sbp_configure_deprecated_configs+=()
+}
+
+configure::deprecate::_add_array() {
+  local old_config_name=$1 new_config_name=$2 default_elements=$3
+  _sbp_configure_deprecated_arrays+=("$old_config_name:$new_config_name:$default_elements")
+}
+
+configure::deprecate::reset() {
+  local old_config_name
+  for old_config_name in "${_sbp_configure_deprecated_configs[@]}"; do
+    unset -n "$old_config_name"
+  done
+  unset -v _sbp_configure_deprecated_configs
+
+  local entry new_config_name default_elements
+  for entry in "${_sbp_configure_deprecated_arrays[@]}"; do
+    old_config_name=${entry%%:*} entry=${entry#*:}
+    new_config_name=${entry%%:*} entry=${entry#*:}
+    default_elements=$entry
+    if ! declare -p "$new_config_name" &>/dev/null; then
+      if declare -p "$old_config_name" &>/dev/null; then
+        if configure::deprecate::_is_warning_enabled; then
+          local sgr0=$'\e[m' sgr_file=$'\e[35m' sgr_sep=$'\e[36m' sgr_old=$'\e[1;31m' sgr_new=$'\e[1;34m'
+          printf '%s\n' "$sgr_file$config_file$sgr_sep:$sgr0 Array '$sgr_old$old_config_name$sgr0' is deprecated. Please assign to '$sgr_new$new_config_name$sgr0'." >/dev/tty
+        fi
+        eval -- "$new_config_name=(\"\${$old_config_name[@]}\")"
+      else
+        eval -- "$new_config_name=($default_elements)"
+      fi
+    fi
+  done
+}
+
+configure::deprecate::setup() {
+  # List of deprecated configuration variables
+
+  # commit 3c9b999f24445441fa828627c6b269e8c322704b
+  configure::deprecate::_add_scalar color00 color0
+  configure::deprecate::_add_scalar color01 color1
+  configure::deprecate::_add_scalar color02 color2
+  configure::deprecate::_add_scalar color03 color3
+  configure::deprecate::_add_scalar color04 color4
+  configure::deprecate::_add_scalar color05 color5
+  configure::deprecate::_add_scalar color06 color6
+  configure::deprecate::_add_scalar color07 color7
+  configure::deprecate::_add_scalar color08 color8
+  configure::deprecate::_add_scalar color09 color9
+  configure::deprecate::_add_scalar color0A color10
+  configure::deprecate::_add_scalar color0B color11
+  configure::deprecate::_add_scalar color0C color12
+  configure::deprecate::_add_scalar color0D color13
+  configure::deprecate::_add_scalar color0E color14
+  configure::deprecate::_add_scalar color0F color15
+
+  configure::deprecate::_add_array settings_hooks          SBP_HOOKS          "'alert'"
+  configure::deprecate::_add_array settings_segments_left  SBP_SEGMENTS_LEFT  "'host' 'path' 'python_env' 'k8s' 'git' 'nix'"
+  configure::deprecate::_add_array settings_segments_right RBP_SEGMENTS_RIGHT "'command' 'timestamp'"
+
+  configure::deprecate::_add_scalar settings_theme_color             SBP_THEME_COLOR
+  configure::deprecate::_add_scalar settings_theme_layout            SBP_THEME_LAYOUT
+  configure::deprecate::_add_scalar settings_timestamp_format        SEGMENTS_TIMESTAMP_FORMAT
+  configure::deprecate::_add_scalar settings_openshift_default_user  SEGMENTS_K8S_DEFAULT_USER
+  configure::deprecate::_add_scalar settings_openshift_hide_cluster  SEGMENTS_K8S_HIDE_CLUSTER
+  configure::deprecate::_add_scalar settings_rescuetime_refresh_rate SEGMENTS_RESCUETIME_REFRESH_RATE
+  configure::deprecate::_add_scalar settings_git_icon                SEGMENTS_GIT_ICON              'This will be set up by layout.'
+  configure::deprecate::_add_scalar settings_git_incoming_icon       SEGMENTS_GIT_INCOMING_ICON     'This will be set up by layout.'
+  configure::deprecate::_add_scalar settings_git_outgoing_icon       SEGMENTS_GIT_OUTGOING_ICON     'This will be set up by layout.'
+  configure::deprecate::_add_scalar settings_path_splitter_disable   SEGMENTS_PATH_SPLITTER_DISABLE 'This will be set up by layout.'
+  configure::deprecate::_add_scalar settings_prompt_ready_icon       SEGMENTS_PROMPT_READY_ICON     'This will be set up by layout.'
+
+  configure::deprecate::_add_scalar settings_command_color_primary              SEGMENTS_COMMAND_COLOR_PRIMARY
+  configure::deprecate::_add_scalar settings_command_color_secondary            SEGMENTS_COMMAND_COLOR_SECONDARY
+  configure::deprecate::_add_scalar settings_command_color_primary_error        SEGMENTS_COMMAND_COLOR_PRIMARY_HIGHLIGHT
+  configure::deprecate::_add_scalar settings_command_color_secondary_error      SEGMENTS_COMMAND_COLOR_SECONDARY_HIGHLIGHT
+  configure::deprecate::_add_scalar settings_git_color_primary                  SEGMENTS_GIT_COLOR_PRIMARY
+  configure::deprecate::_add_scalar settings_git_color_secondary                SEGMENTS_GIT_COLOR_SECONDARY
+  configure::deprecate::_add_scalar settings_host_color_primary                 SEGMENTS_HOST_COLOR_PRIMARY
+  configure::deprecate::_add_scalar settings_host_color_secondary               SEGMENTS_HOST_COLOR_SECONDARY
+  configure::deprecate::_add_scalar settings_host_root_color_primary            SEGMENTS_HOST_COLOR_PRIMARY_HIGHLIGHT
+  configure::deprecate::_add_scalar settings_host_root_color_secondary          SEGMENTS_HOST_COLOR_SECONDARY_HIGHLIGHT
+  configure::deprecate::_add_scalar settings_path_color_primary                 SEGMENTS_PATH_COLOR_PRIMARY
+  configure::deprecate::_add_scalar settings_path_color_secondary               SEGMENTS_PATH_COLOR_SECONDARY
+  configure::deprecate::_add_scalar settings_path_splitter_color                SEGMENTS_PATH_COLOR_SPLITTER
+  configure::deprecate::_add_scalar settings_path_readonly_color_secondary      SEGMENTS_PATH_RO_COLOR_SECONDARY
+  configure::deprecate::_add_scalar settings_path_readonly_color_primary        SEGMENTS_PATH_RO_COLOR_PRIMARY
+  configure::deprecate::_add_scalar settings_prompt_ready_color_primary         SEGMENTS_PROMPT_READY_COLOR_PRIMARY
+  configure::deprecate::_add_scalar settings_prompt_ready_color_secondary       SEGMENTS_PROMPT_READY_COLOR_SECONDARY
+  configure::deprecate::_add_scalar settings_python_virtual_env_color_primary   SEGMENTS_PYTHON_ENV_COLOR_PRIMARY
+  configure::deprecate::_add_scalar settings_python_virtual_env_color_secondary SEGMENTS_PYTHON_ENV_COLOR_SECONDARY
+  configure::deprecate::_add_scalar settings_return_code_color_primary          SEGMENTS_RETURN_CODE_COLOR_PRIMARY
+  configure::deprecate::_add_scalar settings_return_code_color_secondary        SEGMENTS_RETURN_CODE_COLOR_SECONDARY
+  configure::deprecate::_add_scalar settings_timestamp_color_primary            SEGMENTS_TIMESTAMP_COLOR_PRIMARY
+  configure::deprecate::_add_scalar settings_timestamp_color_secondary          SEGMENTS_TIMESTAMP_COLOR_SECONDARY
+  configure::deprecate::_add_scalar settings_aws_color_primary                  SEGMENTS_AWS_COLOR_PRIMARY
+  configure::deprecate::_add_scalar settings_aws_color_secondary                SEGMENTS_AWS_COLOR_SECONDARY
+  configure::deprecate::_add_scalar settings_openshift_color_primary            SEGMENTS_K8S_COLOR_PRIMARY
+  configure::deprecate::_add_scalar settings_openshift_color_secondary          SEGMENTS_K8S_COLOR_SECONDARY
+  configure::deprecate::_add_scalar settings_rescuetime_color_primary           SEGMENTS_RESCUETIME_COLOR_PRIMARY
+  configure::deprecate::_add_scalar settings_rescuetime_color_secondary         SEGMENTS_RESCUETIME_COLOR_SECONDARY
+  configure::deprecate::_add_scalar settings_rescuetime_splitter_color          SEGMENTS_RESCUETIME_SPLITTER_COLOR
+  configure::deprecate::_add_scalar settings_prompt_ready_vi_mode          ''
+  configure::deprecate::_add_scalar settings_prompt_ready_newline          ''
+  configure::deprecate::_add_scalar settings_prompt_ready_vi_insert_color  ''
+  configure::deprecate::_add_scalar settings_prompt_ready_vi_command_color ''
+
+  # commit 3e2eba8f62098fb07be071445482494c4b36c03f
+  configure::deprecate::_add_scalar SEGMENTS_PATH_SPLITTER_COLOR SEGMENTS_PATH_COLOR_SPLITTER
+
+  # commit b3b3c0ba039036ef7eeccddfa3e9fda26eda1642
+  configure::deprecate::_add_scalar SEGMENTS_PATH_READONLY_COLOR_SECONDARY SEGMENTS_PATH_RO_COLOR_SECONDARY
+  configure::deprecate::_add_scalar SEGMENTS_PATH_READONLY_COLOR_PRIMARY   SEGMENTS_PATH_RO_COLOR_PRIMARY
+
+  # commit f5d0b29e2647ce644ea01be469da10a3cbb4939d
+  configure::deprecate::_add_scalar SETTINGS_WTTR_LOCATION SEGMENTS_WTTR_LOCATION
+  configure::deprecate::_add_scalar SETTINGS_WTTR_FORMAT   SEGMENTS_WTTR_FORMAT
+}
+
 configure::load_config() {
   [[ -d "$SBP_CACHE" ]] || mkdir -p "$SBP_CACHE"
 
@@ -93,6 +235,8 @@ configure::load_config() {
     cp "$colors_template" "$colors_file"
   fi
 
+  configure::deprecate::setup
+
   # shellcheck source=/dev/null
   source "$config_file"
   source "$default_config"
@@ -101,4 +245,6 @@ configure::load_config() {
   # shellcheck source=/dev/null
   source "$colors_file"
   source "$default_colors"
+
+  configure::deprecate::reset
 }

--- a/src/configure.bash
+++ b/src/configure.bash
@@ -37,7 +37,7 @@ configure::get_feature_file() {
   else
     debug::log "Could not find $local_file"
     debug::log "Could not find $global_file"
-    debug::log "Make sure at least on of them exists"
+    debug::log "Make sure at least one of them exists"
   fi
 
 }

--- a/src/main.bash
+++ b/src/main.bash
@@ -27,7 +27,7 @@ main::main() {
   left_segment_count=${#SBP_SEGMENTS_LEFT[@]}
   right_segment_count=${#SBP_SEGMENTS_RIGHT[@]}
   total_segment_count=$(( left_segment_count + right_segment_count ))
-  SEGMENTS_MAX_LENGTH=$(( COLUMNS / total_segment_count ))
+  SEGMENTS_MAX_LENGTH=$(( COLUMNS / (total_segment_count ? total_segment_count : 1) ))
 
   for group in "${segment_groups[@]}"; do
     # Bash doesn't support array -> array, so we use pointers instead :(


### PR DESCRIPTION
@brujoand Thank you for reviewing and merging #117 and #118! Based on these PRs, I here create a new PR that solves #100. In this PR, I add a framework to detect the uses of older variable names and then added a list of older variable names in the git history. This framework can also be used for future changes.

When the uses of old variable names are detected, the values are reflected in corresponding new variables. With this change, the old configuration file for 2019-12 `sbp` can be loaded and works as expected, but produces the warning messages, which includes the information on how we can update the configuration file.

## Example:

#### settings.conf

```bash
#!/usr/bin/env bash
settings_theme_color='default'
settings_theme_layout='powerline'

# Hooks will run once before every prompt
# Run 'sbp hooks' to list all available hooks
settings_hooks=('alert')

# Segments are generated before each prompt and can
# be added, removed and reordered
# Run 'sbp segments' to list all available segments
# Maybe you don't want to run all segments when in
# a multiplexer?
if [[ "$TERM" = "screen" || -n "$TMUX" ]]; then
  # We're inside tmux or screen
  settings_segments_left=('path' 'python_env' 'git' 'commend')
  settings_segments_right=('')
else
  settings_segments_left=('host' 'path' 'python_env' 'git' )
  settings_segments_right=('command' 'timestamp')
fi

# General settings, which might be overridden by themes
settings_git_icon=''
settings_git_incoming_icon='↓'
settings_git_outgoing_icon='↑'
settings_path_splitter_disable=0
settings_prompt_ready_vi_mode=0
settings_prompt_ready_icon='➜'
settings_prompt_ready_newline=1
settings_timestamp_format="%H:%M:%S"
settings_openshift_default_user="$USER"
settings_rescuetime_refresh_rate=600
```

#### colors.conf

```bash
#!/usr/bin/env bash

# Color configuration for the segments.
# Check the actualy colors ofr the current theme
# Using 'sbp colors'

settings_command_color_primary=$color04
settings_command_color_secondary=$color01
settings_command_color_primary_error=$color08
settings_command_color_secondary_error=$color04

settings_git_color_primary=$color0A
settings_git_color_secondary=$color01

settings_host_color_primary=$color02
settings_host_color_secondary=$color05
settings_host_root_color_primary=$color09
settings_host_root_color_secondary=$color00

settings_path_color_primary=$color0E
settings_path_color_secondary=$color07
settings_path_splitter_color=$color04

settings_path_readonly_color_secondary=$color0F
settings_path_readonly_color_primary=$color1

settings_prompt_ready_color_primary=''
settings_prompt_ready_color_secondary=$color04
settings_prompt_ready_vi_insert_color=$color04
settings_prompt_ready_vi_command_color=$color0E

settings_python_virtual_env_color_primary=$color09
settings_python_virtual_env_color_secondary=$color0F

settings_return_code_color_primary=$color1
settings_return_code_color_secondary=$color0F

settings_timestamp_color_primary=$color02
settings_timestamp_color_secondary=$color05

settings_aws_color_primary=$color08
settings_aws_color_secondary=$color09

settings_openshift_color_primary=$color08
settings_openshift_color_secondary=$color09

settings_rescuetime_color_primary=$color09
settings_rescuetime_color_secondary=$color0F
settings_rescuetime_splitter_color=$color07
```

#### Warning messages containing the instruction for updating configuration files

```
/home/murase/.config/sbp/settings.conf:2: 'settings_theme_color' is deprecated. Please use 'SBP_THEME_COLOR'.
/home/murase/.config/sbp/settings.conf:3: 'settings_theme_layout' is deprecated. Please use 'SBP_THEME_LAYOUT'.
/home/murase/.config/sbp/settings.conf:24: 'settings_git_icon' is deprecated. Please use 'SEGMENTS_GIT_ICON'.
/home/murase/.config/sbp/settings.conf:25: 'settings_git_incoming_icon' is deprecated. Please use 'SEGMENTS_GIT_INCOMING_ICON'.
/home/murase/.config/sbp/settings.conf:26: 'settings_git_outgoing_icon' is deprecated. Please use 'SEGMENTS_GIT_OUTGOING_ICON'.
/home/murase/.config/sbp/settings.conf:27: 'settings_path_splitter_disable' is deprecated. Please use 'SEGMENTS_PATH_SPLITTER_DISABLE'.
/home/murase/.config/sbp/settings.conf:28: 'settings_prompt_ready_vi_mode' is deprecated.
/home/murase/.config/sbp/settings.conf:29: 'settings_prompt_ready_icon' is deprecated. Please use 'SEGMENTS_PROMPT_READY_ICON'.
/home/murase/.config/sbp/settings.conf:30: 'settings_prompt_ready_newline' is deprecated.
/home/murase/.config/sbp/settings.conf:31: 'settings_timestamp_format' is deprecated. Please use 'SEGMENTS_TIMESTAMP_FORMAT'.
/home/murase/.config/sbp/settings.conf:32: 'settings_openshift_default_user' is deprecated. Please use 'SEGMENTS_K8S_DEFAULT_USER'.
/home/murase/.config/sbp/settings.conf:33: 'settings_rescuetime_refresh_rate' is deprecated. Please use 'SEGMENTS_RESCUETIME_REFRESH_RATE'.
/home/murase/.config/sbp/colors.conf:7: 'color04' is deprecated. Please use 'color4'.
/home/murase/.config/sbp/colors.conf:7: 'settings_command_color_primary' is deprecated. Please use 'SEGMENTS_COMMAND_COLOR_PRIMARY'.
/home/murase/.config/sbp/colors.conf:8: 'color01' is deprecated. Please use 'color1'.
/home/murase/.config/sbp/colors.conf:8: 'settings_command_color_secondary' is deprecated. Please use 'SEGMENTS_COMMAND_COLOR_SECONDARY'.
/home/murase/.config/sbp/colors.conf:9: 'color08' is deprecated. Please use 'color8'.
/home/murase/.config/sbp/colors.conf:9: 'settings_command_color_primary_error' is deprecated. Please use 'SEGMENTS_COMMAND_COLOR_PRIMARY_HIGHLIGHT'.
/home/murase/.config/sbp/colors.conf:10: 'color04' is deprecated. Please use 'color4'.
/home/murase/.config/sbp/colors.conf:10: 'settings_command_color_secondary_error' is deprecated. Please use 'SEGMENTS_COMMAND_COLOR_SECONDARY_HIGHLIGHT'.
/home/murase/.config/sbp/colors.conf:12: 'color0A' is deprecated. Please use 'color10'.
/home/murase/.config/sbp/colors.conf:12: 'settings_git_color_primary' is deprecated. Please use 'SEGMENTS_GIT_COLOR_PRIMARY'.
/home/murase/.config/sbp/colors.conf:13: 'color01' is deprecated. Please use 'color1'.
/home/murase/.config/sbp/colors.conf:13: 'settings_git_color_secondary' is deprecated. Please use 'SEGMENTS_GIT_COLOR_SECONDARY'.
/home/murase/.config/sbp/colors.conf:15: 'color02' is deprecated. Please use 'color2'.
/home/murase/.config/sbp/colors.conf:15: 'settings_host_color_primary' is deprecated. Please use 'SEGMENTS_HOST_COLOR_PRIMARY'.
/home/murase/.config/sbp/colors.conf:16: 'color05' is deprecated. Please use 'color5'.
/home/murase/.config/sbp/colors.conf:16: 'settings_host_color_secondary' is deprecated. Please use 'SEGMENTS_HOST_COLOR_SECONDARY'.
/home/murase/.config/sbp/colors.conf:17: 'color09' is deprecated. Please use 'color9'.
/home/murase/.config/sbp/colors.conf:17: 'settings_host_root_color_primary' is deprecated. Please use 'SEGMENTS_HOST_COLOR_PRIMARY_HIGHLIGHT'.
/home/murase/.config/sbp/colors.conf:18: 'color00' is deprecated. Please use 'color0'.
/home/murase/.config/sbp/colors.conf:18: 'settings_host_root_color_secondary' is deprecated. Please use 'SEGMENTS_HOST_COLOR_SECONDARY_HIGHLIGHT'.
/home/murase/.config/sbp/colors.conf:20: 'color0E' is deprecated. Please use 'color14'.
/home/murase/.config/sbp/colors.conf:20: 'settings_path_color_primary' is deprecated. Please use 'SEGMENTS_PATH_COLOR_PRIMARY'.
/home/murase/.config/sbp/colors.conf:21: 'color07' is deprecated. Please use 'color7'.
/home/murase/.config/sbp/colors.conf:21: 'settings_path_color_secondary' is deprecated. Please use 'SEGMENTS_PATH_COLOR_SECONDARY'.
/home/murase/.config/sbp/colors.conf:22: 'color04' is deprecated. Please use 'color4'.
/home/murase/.config/sbp/colors.conf:22: 'settings_path_splitter_color' is deprecated. Please use 'SEGMENTS_PATH_COLOR_SPLITTER'.
/home/murase/.config/sbp/colors.conf:24: 'color0F' is deprecated. Please use 'color15'.
/home/murase/.config/sbp/colors.conf:24: 'settings_path_readonly_color_secondary' is deprecated. Please use 'SEGMENTS_PATH_RO_COLOR_SECONDARY'.
/home/murase/.config/sbp/colors.conf:25: 'settings_path_readonly_color_primary' is deprecated. Please use 'SEGMENTS_PATH_RO_COLOR_PRIMARY'.
/home/murase/.config/sbp/colors.conf:27: 'settings_prompt_ready_color_primary' is deprecated. Please use 'SEGMENTS_PROMPT_READY_COLOR_PRIMARY'.
/home/murase/.config/sbp/colors.conf:28: 'color04' is deprecated. Please use 'color4'.
/home/murase/.config/sbp/colors.conf:28: 'settings_prompt_ready_color_secondary' is deprecated. Please use 'SEGMENTS_PROMPT_READY_COLOR_SECONDARY'.
/home/murase/.config/sbp/colors.conf:29: 'color04' is deprecated. Please use 'color4'.
/home/murase/.config/sbp/colors.conf:29: 'settings_prompt_ready_vi_insert_color' is deprecated.
/home/murase/.config/sbp/colors.conf:30: 'color0E' is deprecated. Please use 'color14'.
/home/murase/.config/sbp/colors.conf:30: 'settings_prompt_ready_vi_command_color' is deprecated.
/home/murase/.config/sbp/colors.conf:32: 'color09' is deprecated. Please use 'color9'.
/home/murase/.config/sbp/colors.conf:32: 'settings_python_virtual_env_color_primary' is deprecated. Please use 'SEGMENTS_PYTHON_ENV_COLOR_PRIMARY'.
/home/murase/.config/sbp/colors.conf:33: 'color0F' is deprecated. Please use 'color15'.
/home/murase/.config/sbp/colors.conf:33: 'settings_python_virtual_env_color_secondary' is deprecated. Please use 'SEGMENTS_PYTHON_ENV_COLOR_SECONDARY'.
/home/murase/.config/sbp/colors.conf:35: 'settings_return_code_color_primary' is deprecated. Please use 'SEGMENTS_RETURN_CODE_COLOR_PRIMARY'.
/home/murase/.config/sbp/colors.conf:36: 'color0F' is deprecated. Please use 'color15'.
/home/murase/.config/sbp/colors.conf:36: 'settings_return_code_color_secondary' is deprecated. Please use 'SEGMENTS_RETURN_CODE_COLOR_SECONDARY'.
/home/murase/.config/sbp/colors.conf:38: 'color02' is deprecated. Please use 'color2'.
/home/murase/.config/sbp/colors.conf:38: 'settings_timestamp_color_primary' is deprecated. Please use 'SEGMENTS_TIMESTAMP_COLOR_PRIMARY'.
/home/murase/.config/sbp/colors.conf:39: 'color05' is deprecated. Please use 'color5'.
/home/murase/.config/sbp/colors.conf:39: 'settings_timestamp_color_secondary' is deprecated. Please use 'SEGMENTS_TIMESTAMP_COLOR_SECONDARY'.
/home/murase/.config/sbp/colors.conf:41: 'color08' is deprecated. Please use 'color8'.
/home/murase/.config/sbp/colors.conf:41: 'settings_aws_color_primary' is deprecated. Please use 'SEGMENTS_AWS_COLOR_PRIMARY'.
/home/murase/.config/sbp/colors.conf:42: 'color09' is deprecated. Please use 'color9'.
/home/murase/.config/sbp/colors.conf:42: 'settings_aws_color_secondary' is deprecated. Please use 'SEGMENTS_AWS_COLOR_SECONDARY'.
/home/murase/.config/sbp/colors.conf:44: 'color08' is deprecated. Please use 'color8'.
/home/murase/.config/sbp/colors.conf:44: 'settings_openshift_color_primary' is deprecated. Please use 'SEGMENTS_K8S_COLOR_PRIMARY'.
/home/murase/.config/sbp/colors.conf:45: 'color09' is deprecated. Please use 'color9'.
/home/murase/.config/sbp/colors.conf:45: 'settings_openshift_color_secondary' is deprecated. Please use 'SEGMENTS_K8S_COLOR_SECONDARY'.
/home/murase/.config/sbp/colors.conf:47: 'color09' is deprecated. Please use 'color9'.
/home/murase/.config/sbp/colors.conf:47: 'settings_rescuetime_color_primary' is deprecated. Please use 'SEGMENTS_RESCUETIME_COLOR_PRIMARY'.
/home/murase/.config/sbp/colors.conf:48: 'color0F' is deprecated. Please use 'color15'.
/home/murase/.config/sbp/colors.conf:48: 'settings_rescuetime_color_secondary' is deprecated. Please use 'SEGMENTS_RESCUETIME_COLOR_SECONDARY'.
/home/murase/.config/sbp/colors.conf:49: 'color07' is deprecated. Please use 'color7'.
/home/murase/.config/sbp/colors.conf:49: 'settings_rescuetime_splitter_color' is deprecated. Please use 'SEGMENTS_RESCUETIME_SPLITTER_COLOR'.
/home/murase/.config/sbp/settings.conf: Array 'settings_hooks' is deprecated. Please assign to 'SBP_HOOKS'.
/home/murase/.config/sbp/settings.conf: Array 'settings_segments_left' is deprecated. Please assign to 'SBP_SEGMENTS_LEFT'.
/home/murase/.config/sbp/settings.conf: Array 'settings_segments_right' is deprecated. Please assign to 'RBP_SEGMENTS_RIGHT'.
```


