### PR TITLE
Enhance K8s segment

### DIFF
--- a/src/segments/k8s.bash
+++ b/src/segments/k8s.bash
@@ -1,11 +1,11 @@
 #! /usr/bin/env bash
-KUBE_CONFIG="${HOME}/.kube/config"
+[[ -z "$KUBECONFIG" ]] && KUBECONFIG="${HOME}/.kube/config"
 
 segments::k8s() {
-  [[ -f "$KUBE_CONFIG" ]] || return 0
-  context="$(sed -n 's/.*current-context: \(.*\)/\1/p' "$KUBE_CONFIG")"
+  [[ -f "$KUBECONFIG" ]] || return 0
+  context="$(sed -n 's/.*current-context: \(.*\)/\1/p' "$KUBECONFIG")"
   [[ -z "$context" ]] && return 0
-  namespace="$(pcregrep -M -- "- context:\n(^\s\s\w*.*\n)*  name: ${context}" ${KUBE_CONFIG} | sed -n 's/ *namespace: \(\w*\)/\1/p')"
+  namespace="$(pcregrep -M -- "- context:\n(^\s\s\w*.*\n)*  name: ${context}" ${KUBECONFIG} | sed -n 's/ *namespace: \(\w*\)/\1/p')"
   if [[ -z "$namespace" ]]; then
     namespace='default'
   fi

--- a/src/segments/k8s.bash
+++ b/src/segments/k8s.bash
@@ -11,9 +11,9 @@ segments::k8s() {
   fi
 
   if [[ -z $namespace || "$SEGMENTS_K8S_HIDE_CLUSTER" -eq 1 ]]; then
-    segment="${context}"
+    segment="⊛ ${context}"
   else
-    segment="${context}/${namespace}"
+    segment="⊛ ${context}/${namespace}"
   fi
 
   print_themed_segment 'normal' "${segment,,}"

--- a/src/segments/k8s.bash
+++ b/src/segments/k8s.bash
@@ -10,10 +10,12 @@ segments::k8s() {
     namespace='default'
   fi
 
+  local segment_icon_char="${SEGMENTS_K8S_ICON:-⎈}"
+
   if [[ -z $namespace || "$SEGMENTS_K8S_HIDE_CLUSTER" -eq 1 ]]; then
-    segment="⊛ ${context}"
+    segment="${segment_icon_char} ${context}"
   else
-    segment="⊛ ${context}/${namespace}"
+    segment="${segment_icon_char} ${context}/${namespace}"
   fi
 
   print_themed_segment 'normal' "${segment,,}"


### PR DESCRIPTION
Give the K8s segment some love. Adds small features so far:

![k8s-segment](https://user-images.githubusercontent.com/15898292/204778633-a8d15586-b36c-4acf-8763-66f55d4c5555.png)

* use [canonical](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/#the-kubeconfig-environment-variable) environment variable name for *kubeconfig*
* add Nerd-Fonts symbol
  + [x] TODO: make this configurable