### PR TITLE
Create .config/sbp if not exists

### DIFF
--- a/src/configure.bash
+++ b/src/configure.bash
@@ -1,6 +1,7 @@
 #! /usr/bin/env bash
 
 SBP_CONFIG="${XDG_CONFIG_HOME:-$HOME/.config}/sbp"
+mkdir -p "${SBP_CONFIG}"
 config_file="${SBP_CONFIG}/settings.conf"
 colors_file="${SBP_CONFIG}/colors.conf"
 config_template="${SBP_PATH}/config/settings.conf.template"


### PR DESCRIPTION
If this folder does not exist , `sbp.bash` fails with
```text
cp: cannot create regular file '/home/vlad/.config/sbp/colors.conf': No such file or directory
/home/vlad/sbp/src/configure.bash: line 97: /home/vlad/.config/sbp/settings.conf: No such file or directory
/home/vlad/sbp/src/configure.bash: line 102: /home/vlad/.config/sbp/colors.conf: No such file or directory
/home/vlad/sbp/src/main.bash: line 30: COLUMNS / total_segment_count: divis
```
and completely breaks bash prompt.

I'm not sure if it would be better to create this folder via `bin/install`, but I think that `sbp.bash` should be at least somewhat failproof and it definitely shouldn't blow up in user's face just because of config directory.