### PR TITLE
feat!: Write logs to `$XDG_STATE_HOME`

### DIFF
--- a/src/configure.bash
+++ b/src/configure.bash
@@ -9,6 +9,7 @@ colors_template="${SBP_PATH}/config/colors.conf.template"
 default_colors="${SBP_PATH}/config/colors.conf"
 default_config="${SBP_PATH}/config/settings.conf"
 SBP_CACHE="${XDG_CACHE_HOME:-$HOME/.cache}/sbp"
+SBP_STATE="${XDG_STATE_HOME:-$HOME/.local/state}/sbp"
 
 configure::list_feature_files() {
   local feature_type=$1
@@ -80,7 +81,8 @@ configure::set_layout() {
 }
 
 configure::load_config() {
-  [[ -d $SBP_CACHE ]] || mkdir -p "$SBP_CACHE"
+  [[ -d ${SBP_CACHE} ]] || mkdir -p "${SBP_CACHE}"
+  [[ -d ${SBP_STATE}/log ]] || mkdir -p "${SBP_STATE}/log"
 
   if [[ ! -f $config_file ]]; then
     debug::log "Config file not found: ${config_file}"

--- a/src/execute.bash
+++ b/src/execute.bash
@@ -20,7 +20,7 @@ execute::execute_nohup_function() {
   (
     trap '' HUP INT
     "$@"
-  ) </dev/null &>>"${SBP_CONFIG}/hook.log" &
+  ) </dev/null &>>"${SBP_STATE}/log/hook.log" &
 }
 
 execute::execute_prompt_hooks() {

--- a/test/asserts.bash
+++ b/test/asserts.bash
@@ -1,5 +1,12 @@
 #! /usr/bin/env bash
 
+assert() {
+  if ! "$@"; then
+    echo "Assertion failed: $*"
+    false
+  fi
+}
+
 assert_equal() {
   if [[ $1 != "$2" ]]; then
     echo "expected: '$2'"

--- a/test/execute.bats
+++ b/test/execute.bats
@@ -4,7 +4,10 @@ load src_helper
 
 setup() {
   export SBP_CONFIG="${TMP_DIR}/local_config"
+  export SBP_STATE="${TMP_DIR}/local_state"
   mkdir -p "$SBP_CONFIG"/{hooks,segments,peekabo}
+  export SBP_STATE="${TMP_DIR}/local_state"
+  mkdir -p "$SBP_STATE/log"
 }
 
 # Helpers that override SBP functions
@@ -29,6 +32,9 @@ segments::test_segment() {
   execute::execute_prompt_hooks
   read -r result <"$pipe_name"
   assert_equal "$result" 'success'
+
+  # Check that the hook log file was created
+  assert [ -f "${SBP_STATE}/log/hook.log" ]
 }
 
 @test "test that we pass the correct environment variables to segments" {


### PR DESCRIPTION
This PR updates the path that the `hook.log` gets written by default from `$XDG_CONFIG_HOME/sbp` to `$XDG_STATE_HOME/sbp/log`.

This is more in line with the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/latest/#variables):

> The $XDG_STATE_HOME contains state data that should persist between (application) restarts, but that is not important or portable enough to the user that it should be stored in $XDG_DATA_HOME. It may contain:
>
> - actions history (logs, history, recently used files, …)

`$XDG_STATE_HOME/sbp/log` was chosen because `$XDG_STATE_HOME/sbp` could contain different types of state in the future and I think it makes sense to give logs their own directory.

Fixes #141 