### PR TITLE
fix: CI version matrix

### DIFF
--- a/.github/workflows/pull_request_verify.yaml
+++ b/.github/workflows/pull_request_verify.yaml
@@ -11,19 +11,24 @@ jobs:
     name: "Lint check"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: "Execute shell linting"
         uses: luizm/action-sh-checker@master
         env:
           SHFMT_OPTS: -i 2 -ci -s
+
   pr-test:
     name: "Pull request checks"
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [rc 5.0.17 4.4.23 4.3.48]
+        version:
+          - rc
+          - 5.0.17
+          - 4.4.23
+          - 4.3.48
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: "Execute unit tests"
         run: ./bin/ci_test_wrapper ${{ matrix.version }}
         shell: bash


### PR DESCRIPTION
Fixes the bash version matrix for the `pr-test` pre-submit. Previously `./bin/ci_test_wrapper` was being called with the arguments `rc 5.0.17 4.4.23 4.3.48`. The `ci_test_wrapper` then only uses `$1` as the bash version to test so only the docker image `bash:rc` was being used.

`actions/checkout` is also upgraded to use `v4` since `v2` and `v3` are quite old.