### PR TITLE
refactor(k8s): use grep for k8s segment

### DIFF
--- a/src/segments/k8s.bash
+++ b/src/segments/k8s.bash
@@ -5,7 +5,7 @@ segments::k8s() {
   [[ -f $KUBECONFIG ]] || return 0
   context="$(sed -n 's/.*current-context: \(.*\)/\1/p' "$KUBECONFIG")"
   [[ -z $context ]] && return 0
-  namespace="$(pcregrep -M -- "- context:\n(^\s\s\w*.*\n)*  name: ${context}" "${KUBECONFIG}" | sed -n 's/ *namespace: \(\w*\)/\1/p')"
+  namespace="$(grep -Pzo "(?s)\n\-\s*context:\n(\s+\w[^\n]*\n)*\s*name: ${context}" "${KUBECONFIG}" | tr '\0' '\n' | sed -n 's/ *namespace: \(\w*\)/\1/p')"
   if [[ -z $namespace ]]; then
     namespace='default'
   fi

--- a/test/configure.bats
+++ b/test/configure.bats
@@ -53,7 +53,7 @@ setup() {
   local result
   touch "$global_config"
   touch "$local_config"
-  # shellcheck disable=SC2317
+  # shellcheck disable=SC2329
   source() { echo "$@"; }
   result="$(configure::set_colors 'local')"
   assert_equal "$result" "$local_config"


### PR DESCRIPTION
This PR updates the `k8s` segment to use `grep` rather than `pcregrep`. It still requires GNU grep but for most users it would be one less thing to install.

* Also fixes a `shellcheck` error where the code of an ignored check seems to have changed.

- #135 