### PR TITLE
feat(segments/git): add worktree/submodule support

### DIFF
--- a/src/segments/git.bash
+++ b/src/segments/git.bash
@@ -10,7 +10,7 @@ segments::git() {
 
   local path=${PWD}
   while [[ $path ]]; do
-    if [[ -d "${path}/.git" ]]; then
+    if [[ -e "${path}/.git" ]]; then
       local git_folder="${path}/.git"
       break
     fi

--- a/test/segments/git.bats
+++ b/test/segments/git.bats
@@ -7,19 +7,22 @@ setup() {
   export SEGMENTS_GIT_ICON=''
 
   cd "$TMP_DIR" || exit 1
+  mkdir -p test-repo
+  cd test-repo || exit 1
   git init &>/dev/null
   git config user.name sbp
   git config user.email sbp@sbp.sbp
   touch readme
   git add readme
   git commit -am "inital commit" &>/dev/null
+  git worktree add -b newbranch ../test-repo-worktree &>/dev/null
 }
 
 @test "test a clean master" {
   mapfile -t result <<<"$(execute_segment)"
   assert_equal "${#result[@]}" 2
   assert_equal "${result[0]}" 'normal'
-  assert_equal "${result[1]}" 'master'
+  assert_equal "${result[1]}" 'main'
 }
 
 @test "test untracked git segment" {
@@ -28,7 +31,7 @@ setup() {
   assert_equal "${#result[@]}" 3
   assert_equal "${result[0]}" 'normal'
   assert_equal "${result[1]}" '?3'
-  assert_equal "${result[2]}" 'master'
+  assert_equal "${result[2]}" 'main'
 }
 
 @test "test commited git segment" {
@@ -40,7 +43,7 @@ setup() {
   assert_equal "${#result[@]}" 3
   assert_equal "${result[0]}" 'normal'
   assert_equal "${result[1]}" '+3'
-  assert_equal "${result[2]}" 'master'
+  assert_equal "${result[2]}" 'main'
 }
 
 @test "test we can use an icon with git segment" {
@@ -54,5 +57,13 @@ setup() {
   assert_equal "${result[0]}" 'normal'
   assert_equal "${result[1]}" '+3'
   assert_equal "${result[2]}" "$SEGMENTS_GIT_ICON"
-  assert_equal "${result[3]}" 'master'
+  assert_equal "${result[3]}" 'main'
+}
+
+@test "test a worktree" {
+  cd ../test-repo-worktree || exit 1
+  mapfile -t result <<<"$(execute_segment)"
+  assert_equal "${#result[@]}" 2
+  assert_equal "${result[0]}" 'normal'
+  assert_equal "${result[1]}" 'newbranch'
 }


### PR DESCRIPTION
Add support for git worktrees and submodules in the 'git' segment. This updates the 'git' segment to look for the `.git` marker in the form of a file or directory.

- Resolves #125 